### PR TITLE
Rename old API names for latest IDA version

### DIFF
--- a/annotate_lineinfo/annotate_lineinfo.py
+++ b/annotate_lineinfo/annotate_lineinfo.py
@@ -23,7 +23,7 @@ def compiland_name(compiland):
 
 def dia_enum_iter(enum):
     """Turn an IDiaEnum* object into a python generator"""
-    for i in xrange(enum.count):
+    for i in range(enum.count):
         yield enum.Next(1)[0]
 
 ##================ DIA ================##
@@ -147,7 +147,7 @@ else:
                 return
             i += 1
         # Add the comment
-        idaapi.add_long_cmt(ea, True, comment)
+        idaapi.add_extra_cmt(ea, True, comment)
 
     def ida_del_anterior_comment(ea):
         """Remove anterior comment from @ea"""
@@ -188,11 +188,11 @@ else:
 
     def ida_add_lineinfo_comment_to_func(dia, ida_func):
         length = ida_func.size()+1
-        ida_add_lineinfo_comment_to_range(dia, ida_func.startEA, length)
+        ida_add_lineinfo_comment_to_range(dia, ida_func.start_ea, length)
 
     def ida_del_lineinfo_comment_from_func(ida_func):
         length = ida_func.size()+1
-        ida_del_lineinfo_comment_from_range(ida_func.startEA, length)
+        ida_del_lineinfo_comment_from_range(ida_func.start_ea, length)
 
     def ida_annotate_lineinfo_dia(dia, include_function_name=True):
         for func,line in dia.iter_function_lineinfo():


### PR DESCRIPTION
This renames some old API names based on https://www.hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml so the plugin works with IDA 7

Additionally, `xrange` has been changed to `range` so this works with Python3

The API renaming might not be comprehensive; I just fixed whatever IDA complained about in the code paths I hit while using it.